### PR TITLE
fix: broken googlechat_test.go after retry-impl

### DIFF
--- a/notify/googlechat/googlechat_test.go
+++ b/notify/googlechat/googlechat_test.go
@@ -50,7 +50,8 @@ func TestGoogleChatRetry(t *testing.T) {
 	require.NoError(t, err)
 
 	t.Run("test retry status code", func(t *testing.T) {
-		for statusCode, expected := range test.RetryTests(test.DefaultRetryCodes()) {
+		retryCodes := append(test.DefaultRetryCodes(), http.StatusTooManyRequests)
+		for statusCode, expected := range test.RetryTests(retryCodes) {
 			actual, _ := notifier.retrier.Check(statusCode, nil)
 			require.Equal(t, expected, actual, fmt.Sprintf("error on status %d", statusCode))
 		}


### PR DESCRIPTION
In #8 we added retries for GoogleChat notifier,
but didn't update the test, resulting in broken test.

Here, we fix that test.
