### PR TITLE
feat: Add Google Chat cardsV2 support with customizable card fields

### DIFF
--- a/config/notifiers.go
+++ b/config/notifiers.go
@@ -190,8 +190,15 @@ var (
 		NotifierConfig: NotifierConfig{
 			VSendResolved: true,
 		},
-		Message:   `{{ template "googlechat.default.message" . }}`,
-		Threading: false,
+		Message:      `{{ template "googlechat.default.message" . }}`,
+		Threading:    false,
+		CardTitle:    `{{ template "googlechat.card.title" . }}`,
+		CardSubtitle: `{{ template "googlechat.card.subtitle" . }}`,
+		CardImageURL: `{{ template "googlechat.card.image_url" . }}`,
+		CardMessage:  `{{ template "googlechat.card.message" . }}`,
+		CardDetails:  `{{ template "googlechat.card.details" . }}`,
+		CardLabels:   `{{ template "googlechat.card.labels" . }}`,
+		CardActions:  `{{ template "googlechat.card.actions" . }}`,
 	}
 )
 
@@ -875,7 +882,7 @@ func (c *MSTeamsV2Config) UnmarshalYAML(unmarshal func(interface{}) error) error
 	return nil
 }
 
-// GoogleChatConfig configures notifications via Discord.
+// GoogleChatConfig configures notifications via Google Chat.
 type GoogleChatConfig struct {
 	NotifierConfig `yaml:",inline" json:",inline"`
 
@@ -885,6 +892,17 @@ type GoogleChatConfig struct {
 
 	Message   string `yaml:"message,omitempty" json:"message,omitempty"`
 	Threading bool   `yaml:"threading,omitempty" json:"threading,omitempty"`
+
+	// Cards v2 fields. When any content field (CardTitle, CardMessage,
+	// CardDetails, CardLabels, or CardActions) renders to a non-empty
+	// string, the notifier sends a cardsV2 payload instead of plain text.
+	CardTitle    string `yaml:"card_title,omitempty" json:"card_title,omitempty"`
+	CardSubtitle string `yaml:"card_subtitle,omitempty" json:"card_subtitle,omitempty"`
+	CardImageURL string `yaml:"card_image_url,omitempty" json:"card_image_url,omitempty"`
+	CardMessage  string `yaml:"card_message,omitempty" json:"card_message,omitempty"`
+	CardDetails  string `yaml:"card_details,omitempty" json:"card_details,omitempty"`
+	CardLabels   string `yaml:"card_labels,omitempty" json:"card_labels,omitempty"`
+	CardActions  string `yaml:"card_actions,omitempty" json:"card_actions,omitempty"`
 }
 
 // UnmarshalYAML implements the yaml.Unmarshaler interface.

--- a/config/notifiers.go
+++ b/config/notifiers.go
@@ -197,7 +197,6 @@ var (
 		CardImageURL: `{{ template "googlechat.card.image_url" . }}`,
 		CardMessage:  `{{ template "googlechat.card.message" . }}`,
 		CardDetails:  `{{ template "googlechat.card.details" . }}`,
-		CardLabels:   `{{ template "googlechat.card.labels" . }}`,
 		CardActions:  `{{ template "googlechat.card.actions" . }}`,
 	}
 )
@@ -894,14 +893,13 @@ type GoogleChatConfig struct {
 	Threading bool   `yaml:"threading,omitempty" json:"threading,omitempty"`
 
 	// Cards v2 fields. When any content field (CardTitle, CardMessage,
-	// CardDetails, CardLabels, or CardActions) renders to a non-empty
-	// string, the notifier sends a cardsV2 payload instead of plain text.
+	// CardDetails, or CardActions) renders to a non-empty string, the
+	// notifier sends a cardsV2 payload instead of plain text.
 	CardTitle    string `yaml:"card_title,omitempty" json:"card_title,omitempty"`
 	CardSubtitle string `yaml:"card_subtitle,omitempty" json:"card_subtitle,omitempty"`
 	CardImageURL string `yaml:"card_image_url,omitempty" json:"card_image_url,omitempty"`
 	CardMessage  string `yaml:"card_message,omitempty" json:"card_message,omitempty"`
 	CardDetails  string `yaml:"card_details,omitempty" json:"card_details,omitempty"`
-	CardLabels   string `yaml:"card_labels,omitempty" json:"card_labels,omitempty"`
 	CardActions  string `yaml:"card_actions,omitempty" json:"card_actions,omitempty"`
 }
 

--- a/notify/googlechat/googlechat.go
+++ b/notify/googlechat/googlechat.go
@@ -54,11 +54,181 @@ func New(conf *config.GoogleChatConfig, t *template.Template, l log.Logger, http
 	}, nil
 }
 
-// Message represents the structure for sending a
-// Text message in Google Chat Webhook endpoint.
-// https://developers.google.com/chat/api/guides/message-formats/basic
-type Message struct {
+// Text-only message payload (legacy format).
+type textMessage struct {
 	Text string `json:"text"`
+}
+
+// Cards v2 payload types.
+// https://developers.google.com/workspace/chat/api/reference/rest/v1/cards
+
+type cardPayload struct {
+	Text    string   `json:"text,omitempty"`
+	CardsV2 []cardV2 `json:"cardsV2,omitempty"`
+}
+
+type cardV2 struct {
+	CardID string   `json:"cardId"`
+	Card   cardBody `json:"card"`
+}
+
+type cardBody struct {
+	Header   *cardHeader `json:"header,omitempty"`
+	Sections []section   `json:"sections,omitempty"`
+}
+
+type cardHeader struct {
+	Title        string `json:"title"`
+	Subtitle     string `json:"subtitle,omitempty"`
+	ImageURL     string `json:"imageUrl,omitempty"`
+	ImageType    string `json:"imageType,omitempty"`
+	ImageAltText string `json:"imageAltText,omitempty"`
+}
+
+type section struct {
+	Header                    string   `json:"header,omitempty"`
+	Widgets                   []widget `json:"widgets"`
+	Collapsible               bool     `json:"collapsible,omitempty"`
+	UncollapsibleWidgetsCount int      `json:"uncollapsibleWidgetsCount,omitempty"`
+}
+
+type widget struct {
+	DecoratedText *decoratedText `json:"decoratedText,omitempty"`
+	ButtonList    *buttonList    `json:"buttonList,omitempty"`
+	TextParagraph *textParagraph `json:"textParagraph,omitempty"`
+	Divider       *divider       `json:"divider,omitempty"`
+}
+
+type decoratedText struct {
+	TopLabel string `json:"topLabel,omitempty"`
+	Text     string `json:"text"`
+	WrapText bool   `json:"wrapText,omitempty"`
+}
+
+type textParagraph struct {
+	Text string `json:"text"`
+}
+
+type buttonList struct {
+	Buttons []button `json:"buttons"`
+}
+
+type button struct {
+	Text    string  `json:"text"`
+	OnClick onClick `json:"onClick"`
+}
+
+type onClick struct {
+	OpenLink openLink `json:"openLink"`
+}
+
+type openLink struct {
+	URL string `json:"url"`
+}
+
+type divider struct{}
+
+func buildCard(title, subtitle, imageURL, message, details, labels, actions string) *cardBody {
+	card := &cardBody{}
+
+	if title != "" {
+		card.Header = &cardHeader{
+			Title:    title,
+			Subtitle: subtitle,
+		}
+		if imageURL != "" {
+			card.Header.ImageURL = imageURL
+			card.Header.ImageType = "CIRCLE"
+			card.Header.ImageAltText = "Alert"
+		}
+	}
+
+	if message != "" {
+		card.Sections = append(card.Sections, section{
+			Widgets: []widget{{TextParagraph: &textParagraph{Text: message}}},
+		})
+	}
+
+	if labels != "" {
+		widgets := parseKeyValueWidgets(labels)
+		if len(widgets) > 0 {
+			card.Sections = append(card.Sections, section{
+				Header:                    "Labels",
+				Widgets:                   widgets,
+				Collapsible:               true,
+				UncollapsibleWidgetsCount: 2,
+			})
+		}
+	}
+
+	if details != "" {
+		widgets := parseKeyValueWidgets(details)
+		if len(widgets) > 0 {
+			card.Sections = append(card.Sections, section{
+				Header:                    "Alert Details",
+				Widgets:                   widgets,
+				Collapsible:               true,
+				UncollapsibleWidgetsCount: 0,
+			})
+		}
+	}
+
+	if actions != "" {
+		buttons := parseActionButtons(actions)
+		if len(buttons) > 0 {
+			card.Sections = append(card.Sections, section{
+				Widgets: []widget{{ButtonList: &buttonList{Buttons: buttons}}},
+			})
+		}
+	}
+
+	return card
+}
+
+func parseKeyValueWidgets(s string) []widget {
+	var widgets []widget
+	for _, line := range strings.Split(s, "\n") {
+		line = strings.TrimSpace(line)
+		if line == "" {
+			continue
+		}
+		parts := strings.SplitN(line, ": ", 2)
+		if len(parts) != 2 {
+			continue
+		}
+		widgets = append(widgets, widget{
+			DecoratedText: &decoratedText{
+				TopLabel: strings.TrimSpace(parts[0]),
+				Text:     strings.TrimSpace(parts[1]),
+				WrapText: true,
+			},
+		})
+	}
+	return widgets
+}
+
+func parseActionButtons(s string) []button {
+	var buttons []button
+	for _, line := range strings.Split(s, "\n") {
+		line = strings.TrimSpace(line)
+		if line == "" {
+			continue
+		}
+		parts := strings.SplitN(line, "|", 2)
+		if len(parts) != 2 {
+			continue
+		}
+		label := strings.TrimSpace(parts[0])
+		link := strings.TrimSpace(parts[1])
+		if label == "" || link == "" {
+			continue
+		}
+		buttons = append(buttons, button{
+			Text:    label,
+			OnClick: onClick{OpenLink: openLink{URL: link}},
+		})
+	}
+	return buttons
 }
 
 // Notify implements the Notifier interface.
@@ -74,17 +244,37 @@ func (n *Notifier) Notify(ctx context.Context, alert ...*types.Alert) (bool, err
 	)
 
 	message := tmpl(n.conf.Message)
+
+	cardTitle := tmpl(n.conf.CardTitle)
+	cardSubtitle := tmpl(n.conf.CardSubtitle)
+	cardImageURL := tmpl(n.conf.CardImageURL)
+	cardMessage := tmpl(n.conf.CardMessage)
+	cardDetails := tmpl(n.conf.CardDetails)
+	cardLabels := tmpl(n.conf.CardLabels)
+	cardActions := tmpl(n.conf.CardActions)
+
 	if err != nil {
 		return false, err
 	}
 
-	msg := &Message{
-		Text: message,
-	}
-
 	var buf bytes.Buffer
-	if err := json.NewEncoder(&buf).Encode(msg); err != nil {
-		return false, err
+	card := buildCard(cardTitle, cardSubtitle, cardImageURL, cardMessage, cardDetails, cardLabels, cardActions)
+	if card.Header != nil || len(card.Sections) > 0 {
+		payload := cardPayload{
+			CardsV2: []cardV2{
+				{
+					CardID: key.Hash(),
+					Card:   *card,
+				},
+			},
+		}
+		if err := json.NewEncoder(&buf).Encode(payload); err != nil {
+			return false, err
+		}
+	} else {
+		if err := json.NewEncoder(&buf).Encode(textMessage{Text: message}); err != nil {
+			return false, err
+		}
 	}
 
 	var webhookURL string
@@ -99,12 +289,6 @@ func (n *Notifier) Notify(ctx context.Context, alert ...*types.Alert) (bool, err
 	}
 
 	// https://developers.google.com/chat/how-tos/webhooks#start_a_message_thread
-	// To post the first message of a thread with a webhook,
-	// append the threadKey and messageReplyOption parameters to the webhook URL.
-	// Set the threadKey to an arbitrary string, but remember what it is;
-	// you'll need to specify it again to post a reply to the thread.
-	// https://chat.googleapis.com/v1/spaces/SPACE_ID/messages?threadKey=ARBITRARY_STRING&messageReplyOption=REPLY_MESSAGE_FALLBACK_TO_NEW_THREAD
-
 	u, err := url.Parse(webhookURL)
 	if err != nil {
 		return false, fmt.Errorf("unable to parse googlechat url: %w", err)

--- a/notify/googlechat/googlechat.go
+++ b/notify/googlechat/googlechat.go
@@ -180,6 +180,10 @@ func parseKeyValueWidgets(s string) []widget {
 		if line == "" {
 			continue
 		}
+		if line == "---" {
+			widgets = append(widgets, widget{Divider: &divider{}})
+			continue
+		}
 		parts := strings.SplitN(line, ": ", 2)
 		if len(parts) != 2 {
 			continue

--- a/notify/googlechat/googlechat.go
+++ b/notify/googlechat/googlechat.go
@@ -128,7 +128,7 @@ type openLink struct {
 
 type divider struct{}
 
-func buildCard(title, subtitle, imageURL, message, details, labels, actions string) *cardBody {
+func buildCard(title, subtitle, imageURL, message, details, actions string) *cardBody {
 	card := &cardBody{}
 
 	if title != "" {
@@ -149,26 +149,14 @@ func buildCard(title, subtitle, imageURL, message, details, labels, actions stri
 		})
 	}
 
-	if labels != "" {
-		widgets := parseKeyValueWidgets(labels)
-		if len(widgets) > 0 {
-			card.Sections = append(card.Sections, section{
-				Header:                    "Labels",
-				Widgets:                   widgets,
-				Collapsible:               true,
-				UncollapsibleWidgetsCount: 2,
-			})
-		}
-	}
-
 	if details != "" {
 		widgets := parseKeyValueWidgets(details)
 		if len(widgets) > 0 {
 			card.Sections = append(card.Sections, section{
-				Header:                    "Alert Details",
+				Header:                    "Details",
 				Widgets:                   widgets,
 				Collapsible:               true,
-				UncollapsibleWidgetsCount: 0,
+				UncollapsibleWidgetsCount: 2,
 			})
 		}
 	}
@@ -250,7 +238,6 @@ func (n *Notifier) Notify(ctx context.Context, alert ...*types.Alert) (bool, err
 	cardImageURL := tmpl(n.conf.CardImageURL)
 	cardMessage := tmpl(n.conf.CardMessage)
 	cardDetails := tmpl(n.conf.CardDetails)
-	cardLabels := tmpl(n.conf.CardLabels)
 	cardActions := tmpl(n.conf.CardActions)
 
 	if err != nil {
@@ -258,7 +245,7 @@ func (n *Notifier) Notify(ctx context.Context, alert ...*types.Alert) (bool, err
 	}
 
 	var buf bytes.Buffer
-	card := buildCard(cardTitle, cardSubtitle, cardImageURL, cardMessage, cardDetails, cardLabels, cardActions)
+	card := buildCard(cardTitle, cardSubtitle, cardImageURL, cardMessage, cardDetails, cardActions)
 	if card.Header != nil || len(card.Sections) > 0 {
 		payload := cardPayload{
 			CardsV2: []cardV2{

--- a/notify/googlechat/googlechat_test.go
+++ b/notify/googlechat/googlechat_test.go
@@ -162,3 +162,191 @@ func TestGooglechatTemplating(t *testing.T) {
 		})
 	}
 }
+
+func TestGooglechatCardMode(t *testing.T) {
+	var receivedPayload map[string]interface{}
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		dec := json.NewDecoder(r.Body)
+		receivedPayload = make(map[string]interface{})
+		if err := dec.Decode(&receivedPayload); err != nil {
+			panic(err)
+		}
+	}))
+	defer srv.Close()
+	u, _ := url.Parse(srv.URL)
+
+	cfg := &config.GoogleChatConfig{
+		URL:          &config.SecretURL{URL: u},
+		HTTPConfig:   &commoncfg.HTTPClientConfig{},
+		Message:      "Preview text",
+		CardTitle:    "Alert: High CPU",
+		CardSubtitle: "Critical | Firing 1",
+		CardImageURL: "https://oodle.ai/img/logo.svg",
+		CardMessage:  "CPU usage exceeded threshold",
+		CardDetails:  "Severity: Critical\nThreshold: 95%\nMetric Value: 98.2%",
+		CardLabels:   "cluster: prod-us-east-1\nnamespace: api-server",
+		CardActions:  "View Alert|https://app.oodle.ai/alerts/123\nAI Insights|https://app.oodle.ai/insights/123",
+	}
+
+	pd, err := New(cfg, test.CreateTmpl(t), log.NewNopLogger())
+	require.NoError(t, err)
+
+	ctx := context.Background()
+	ctx = notify.WithGroupKey(ctx, "test-group")
+
+	ok, err := pd.Notify(ctx, []*types.Alert{
+		{
+			Alert: model.Alert{
+				Labels:   model.LabelSet{"alertname": "HighCPU"},
+				StartsAt: time.Now(),
+				EndsAt:   time.Now().Add(time.Hour),
+			},
+		},
+	}...)
+	require.NoError(t, err)
+	require.False(t, ok)
+
+	// Verify cardsV2 key exists and no duplicate text line
+	require.Contains(t, receivedPayload, "cardsV2")
+	require.NotContains(t, receivedPayload, "text")
+
+	// Verify card structure
+	cardsV2, ok := receivedPayload["cardsV2"].([]interface{})
+	require.True(t, ok)
+	require.Len(t, cardsV2, 1)
+
+	cardEntry, ok := cardsV2[0].(map[string]interface{})
+	require.True(t, ok)
+	require.Contains(t, cardEntry, "cardId")
+	require.Contains(t, cardEntry, "card")
+
+	card, ok := cardEntry["card"].(map[string]interface{})
+	require.True(t, ok)
+
+	// Verify header
+	header, ok := card["header"].(map[string]interface{})
+	require.True(t, ok)
+	require.Equal(t, "Alert: High CPU", header["title"])
+	require.Equal(t, "Critical | Firing 1", header["subtitle"])
+	require.Equal(t, "https://oodle.ai/img/logo.svg", header["imageUrl"])
+
+	// Verify sections exist: message, labels, details, actions
+	sections, ok := card["sections"].([]interface{})
+	require.True(t, ok)
+	require.Len(t, sections, 4)
+}
+
+func TestGooglechatTextFallback(t *testing.T) {
+	var receivedPayload map[string]interface{}
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		dec := json.NewDecoder(r.Body)
+		receivedPayload = make(map[string]interface{})
+		if err := dec.Decode(&receivedPayload); err != nil {
+			panic(err)
+		}
+	}))
+	defer srv.Close()
+	u, _ := url.Parse(srv.URL)
+
+	cfg := &config.GoogleChatConfig{
+		URL:        &config.SecretURL{URL: u},
+		HTTPConfig: &commoncfg.HTTPClientConfig{},
+		Message:    "Plain text alert",
+	}
+
+	pd, err := New(cfg, test.CreateTmpl(t), log.NewNopLogger())
+	require.NoError(t, err)
+
+	ctx := context.Background()
+	ctx = notify.WithGroupKey(ctx, "test-group")
+
+	ok, err := pd.Notify(ctx, []*types.Alert{
+		{
+			Alert: model.Alert{
+				Labels:   model.LabelSet{"alertname": "TestAlert"},
+				StartsAt: time.Now(),
+				EndsAt:   time.Now().Add(time.Hour),
+			},
+		},
+	}...)
+	require.NoError(t, err)
+	require.False(t, ok)
+
+	// Text mode: no cardsV2
+	require.NotContains(t, receivedPayload, "cardsV2")
+	require.Equal(t, "Plain text alert", receivedPayload["text"])
+}
+
+func TestBuildCard(t *testing.T) {
+	t.Run("full card", func(t *testing.T) {
+		card := buildCard(
+			"Alert Title",
+			"Critical",
+			"https://example.com/icon.png",
+			"Something went wrong",
+			"Severity: Critical\nThreshold: 95%",
+			"cluster: prod\nregion: us-east-1\nservice: api",
+			"View|https://example.com\nEdit|https://example.com/edit",
+		)
+
+		require.NotNil(t, card.Header)
+		require.Equal(t, "Alert Title", card.Header.Title)
+		require.Equal(t, "Critical", card.Header.Subtitle)
+		require.Equal(t, "https://example.com/icon.png", card.Header.ImageURL)
+
+		// message + details + labels + actions = 4 sections
+		require.Len(t, card.Sections, 4)
+
+		// Message section
+		require.NotNil(t, card.Sections[0].Widgets[0].TextParagraph)
+		require.Equal(t, "Something went wrong", card.Sections[0].Widgets[0].TextParagraph.Text)
+
+		// Labels section (collapsible, before details)
+		require.Equal(t, "Labels", card.Sections[1].Header)
+		require.True(t, card.Sections[1].Collapsible)
+		require.Equal(t, 2, card.Sections[1].UncollapsibleWidgetsCount)
+		require.Len(t, card.Sections[1].Widgets, 3)
+
+		// Details section (collapsible)
+		require.Equal(t, "Alert Details", card.Sections[2].Header)
+		require.True(t, card.Sections[2].Collapsible)
+		require.Equal(t, 0, card.Sections[2].UncollapsibleWidgetsCount)
+		require.Len(t, card.Sections[2].Widgets, 2)
+		require.Equal(t, "Severity", card.Sections[2].Widgets[0].DecoratedText.TopLabel)
+		require.Equal(t, "Critical", card.Sections[2].Widgets[0].DecoratedText.Text)
+
+		// Actions section
+		require.Len(t, card.Sections[3].Widgets, 1)
+		require.NotNil(t, card.Sections[3].Widgets[0].ButtonList)
+		require.Len(t, card.Sections[3].Widgets[0].ButtonList.Buttons, 2)
+		require.Equal(t, "View", card.Sections[3].Widgets[0].ButtonList.Buttons[0].Text)
+		require.Equal(t, "https://example.com", card.Sections[3].Widgets[0].ButtonList.Buttons[0].OnClick.OpenLink.URL)
+	})
+
+	t.Run("empty fields produce no sections", func(t *testing.T) {
+		card := buildCard("Title", "", "", "", "", "", "")
+		require.NotNil(t, card.Header)
+		require.Len(t, card.Sections, 0)
+	})
+
+	t.Run("handles malformed lines", func(t *testing.T) {
+		card := buildCard("", "", "", "", "no-colon-here\n\nvalid: line", "also bad\nk: v", "no-pipe\nLabel|https://url.com")
+		// labels first: 1 valid widget
+		require.Len(t, card.Sections[0].Widgets, 1)
+		require.Equal(t, "k", card.Sections[0].Widgets[0].DecoratedText.TopLabel)
+		// details: 1 valid widget
+		require.Len(t, card.Sections[1].Widgets, 1)
+		require.Equal(t, "valid", card.Sections[1].Widgets[0].DecoratedText.TopLabel)
+		// actions: 1 valid button
+		require.Len(t, card.Sections[2].Widgets[0].ButtonList.Buttons, 1)
+	})
+
+	t.Run("value containing delimiter", func(t *testing.T) {
+		card := buildCard("", "", "", "", "url: https://example.com:8080/path", "", "")
+		require.Len(t, card.Sections[0].Widgets, 1)
+		require.Equal(t, "url", card.Sections[0].Widgets[0].DecoratedText.TopLabel)
+		require.Equal(t, "https://example.com:8080/path", card.Sections[0].Widgets[0].DecoratedText.Text)
+	})
+}

--- a/notify/googlechat/googlechat_test.go
+++ b/notify/googlechat/googlechat_test.go
@@ -184,8 +184,7 @@ func TestGooglechatCardMode(t *testing.T) {
 		CardSubtitle: "Critical | Firing 1",
 		CardImageURL: "https://oodle.ai/img/logo.svg",
 		CardMessage:  "CPU usage exceeded threshold",
-		CardDetails:  "Severity: Critical\nThreshold: 95%\nMetric Value: 98.2%",
-		CardLabels:   "cluster: prod-us-east-1\nnamespace: api-server",
+		CardDetails:  "cluster: prod-us-east-1\nnamespace: api-server\nSeverity: Critical\nThreshold: 95%\nMetric Value: 98.2%",
 		CardActions:  "View Alert|https://app.oodle.ai/alerts/123\nAI Insights|https://app.oodle.ai/insights/123",
 	}
 
@@ -231,10 +230,10 @@ func TestGooglechatCardMode(t *testing.T) {
 	require.Equal(t, "Critical | Firing 1", header["subtitle"])
 	require.Equal(t, "https://oodle.ai/img/logo.svg", header["imageUrl"])
 
-	// Verify sections exist: message, labels, details, actions
+	// Verify sections exist: message, details, actions
 	sections, ok := card["sections"].([]interface{})
 	require.True(t, ok)
-	require.Len(t, sections, 4)
+	require.Len(t, sections, 3)
 }
 
 func TestGooglechatTextFallback(t *testing.T) {
@@ -286,8 +285,7 @@ func TestBuildCard(t *testing.T) {
 			"Critical",
 			"https://example.com/icon.png",
 			"Something went wrong",
-			"Severity: Critical\nThreshold: 95%",
-			"cluster: prod\nregion: us-east-1\nservice: api",
+			"cluster: prod\nregion: us-east-1\nSeverity: Critical\nThreshold: 95%",
 			"View|https://example.com\nEdit|https://example.com/edit",
 		)
 
@@ -296,55 +294,46 @@ func TestBuildCard(t *testing.T) {
 		require.Equal(t, "Critical", card.Header.Subtitle)
 		require.Equal(t, "https://example.com/icon.png", card.Header.ImageURL)
 
-		// message + details + labels + actions = 4 sections
-		require.Len(t, card.Sections, 4)
+		// message + details + actions = 3 sections
+		require.Len(t, card.Sections, 3)
 
 		// Message section
 		require.NotNil(t, card.Sections[0].Widgets[0].TextParagraph)
 		require.Equal(t, "Something went wrong", card.Sections[0].Widgets[0].TextParagraph.Text)
 
-		// Labels section (collapsible, before details)
-		require.Equal(t, "Labels", card.Sections[1].Header)
+		// Details section (collapsible)
+		require.Equal(t, "Details", card.Sections[1].Header)
 		require.True(t, card.Sections[1].Collapsible)
 		require.Equal(t, 2, card.Sections[1].UncollapsibleWidgetsCount)
-		require.Len(t, card.Sections[1].Widgets, 3)
-
-		// Details section (collapsible)
-		require.Equal(t, "Alert Details", card.Sections[2].Header)
-		require.True(t, card.Sections[2].Collapsible)
-		require.Equal(t, 0, card.Sections[2].UncollapsibleWidgetsCount)
-		require.Len(t, card.Sections[2].Widgets, 2)
-		require.Equal(t, "Severity", card.Sections[2].Widgets[0].DecoratedText.TopLabel)
-		require.Equal(t, "Critical", card.Sections[2].Widgets[0].DecoratedText.Text)
+		require.Len(t, card.Sections[1].Widgets, 4)
+		require.Equal(t, "cluster", card.Sections[1].Widgets[0].DecoratedText.TopLabel)
+		require.Equal(t, "prod", card.Sections[1].Widgets[0].DecoratedText.Text)
 
 		// Actions section
-		require.Len(t, card.Sections[3].Widgets, 1)
-		require.NotNil(t, card.Sections[3].Widgets[0].ButtonList)
-		require.Len(t, card.Sections[3].Widgets[0].ButtonList.Buttons, 2)
-		require.Equal(t, "View", card.Sections[3].Widgets[0].ButtonList.Buttons[0].Text)
-		require.Equal(t, "https://example.com", card.Sections[3].Widgets[0].ButtonList.Buttons[0].OnClick.OpenLink.URL)
+		require.Len(t, card.Sections[2].Widgets, 1)
+		require.NotNil(t, card.Sections[2].Widgets[0].ButtonList)
+		require.Len(t, card.Sections[2].Widgets[0].ButtonList.Buttons, 2)
+		require.Equal(t, "View", card.Sections[2].Widgets[0].ButtonList.Buttons[0].Text)
+		require.Equal(t, "https://example.com", card.Sections[2].Widgets[0].ButtonList.Buttons[0].OnClick.OpenLink.URL)
 	})
 
 	t.Run("empty fields produce no sections", func(t *testing.T) {
-		card := buildCard("Title", "", "", "", "", "", "")
+		card := buildCard("Title", "", "", "", "", "")
 		require.NotNil(t, card.Header)
 		require.Len(t, card.Sections, 0)
 	})
 
 	t.Run("handles malformed lines", func(t *testing.T) {
-		card := buildCard("", "", "", "", "no-colon-here\n\nvalid: line", "also bad\nk: v", "no-pipe\nLabel|https://url.com")
-		// labels first: 1 valid widget
-		require.Len(t, card.Sections[0].Widgets, 1)
-		require.Equal(t, "k", card.Sections[0].Widgets[0].DecoratedText.TopLabel)
+		card := buildCard("", "", "", "", "no-colon-here\n\nvalid: line", "no-pipe\nLabel|https://url.com")
 		// details: 1 valid widget
-		require.Len(t, card.Sections[1].Widgets, 1)
-		require.Equal(t, "valid", card.Sections[1].Widgets[0].DecoratedText.TopLabel)
+		require.Len(t, card.Sections[0].Widgets, 1)
+		require.Equal(t, "valid", card.Sections[0].Widgets[0].DecoratedText.TopLabel)
 		// actions: 1 valid button
-		require.Len(t, card.Sections[2].Widgets[0].ButtonList.Buttons, 1)
+		require.Len(t, card.Sections[1].Widgets[0].ButtonList.Buttons, 1)
 	})
 
 	t.Run("value containing delimiter", func(t *testing.T) {
-		card := buildCard("", "", "", "", "url: https://example.com:8080/path", "", "")
+		card := buildCard("", "", "", "", "url: https://example.com:8080/path", "")
 		require.Len(t, card.Sections[0].Widgets, 1)
 		require.Equal(t, "url", card.Sections[0].Widgets[0].DecoratedText.TopLabel)
 		require.Equal(t, "https://example.com:8080/path", card.Sections[0].Widgets[0].DecoratedText.Text)

--- a/notify/googlechat/googlechat_test.go
+++ b/notify/googlechat/googlechat_test.go
@@ -332,6 +332,17 @@ func TestBuildCard(t *testing.T) {
 		require.Len(t, card.Sections[1].Widgets[0].ButtonList.Buttons, 1)
 	})
 
+	t.Run("divider separates groups", func(t *testing.T) {
+		card := buildCard("", "", "", "", "cluster: prod\n---\nhost: server-1\nMetric Value: 98%\n---\nhost: server-2\nMetric Value: 97%", "")
+		require.Len(t, card.Sections[0].Widgets, 7)
+		require.NotNil(t, card.Sections[0].Widgets[0].DecoratedText)
+		require.Equal(t, "prod", card.Sections[0].Widgets[0].DecoratedText.Text)
+		require.NotNil(t, card.Sections[0].Widgets[1].Divider)
+		require.NotNil(t, card.Sections[0].Widgets[2].DecoratedText)
+		require.Equal(t, "server-1", card.Sections[0].Widgets[2].DecoratedText.Text)
+		require.NotNil(t, card.Sections[0].Widgets[4].Divider)
+	})
+
 	t.Run("value containing delimiter", func(t *testing.T) {
 		card := buildCard("", "", "", "", "url: https://example.com:8080/path", "")
 		require.Len(t, card.Sections[0].Widgets, 1)

--- a/template/default.tmpl
+++ b/template/default.tmpl
@@ -184,3 +184,11 @@ Alerts Resolved:
 {{ template "__text_alert_list_markdown" .Alerts.Resolved }}
 {{- end }}
 {{- end }}
+
+{{ define "googlechat.card.title" }}{{ end }}
+{{ define "googlechat.card.subtitle" }}{{ end }}
+{{ define "googlechat.card.image_url" }}{{ end }}
+{{ define "googlechat.card.message" }}{{ end }}
+{{ define "googlechat.card.details" }}{{ end }}
+{{ define "googlechat.card.labels" }}{{ end }}
+{{ define "googlechat.card.actions" }}{{ end }}

--- a/template/default.tmpl
+++ b/template/default.tmpl
@@ -190,5 +190,4 @@ Alerts Resolved:
 {{ define "googlechat.card.image_url" }}{{ end }}
 {{ define "googlechat.card.message" }}{{ end }}
 {{ define "googlechat.card.details" }}{{ end }}
-{{ define "googlechat.card.labels" }}{{ end }}
 {{ define "googlechat.card.actions" }}{{ end }}


### PR DESCRIPTION
## Summary
- Add `CardTitle`, `CardSubtitle`, `CardImageURL`, `CardMessage`, `CardDetails`, `CardLabels`, and `CardActions` fields to `GoogleChatConfig`
- Implement cardsV2 payload generation with header, sections (details, labels), and action buttons
- Fallback to text-only message when no card fields are configured
- Add comprehensive tests for both card and text modes

## Test plan
- [ ] Verify card mode: configure card fields and confirm cardsV2 payload is generated correctly
- [ ] Verify text fallback: omit card fields and confirm plain text message is sent
- [ ] Run `go test ./notify/googlechat/...` to validate unit tests pass
- [ ] Integration test with a real Google Chat webhook

🤖 Generated with [Claude Code](https://claude.ai/code)