### PR TITLE
fix: truncate Google Chat messages exceeding API size limit

### DIFF
--- a/notify/googlechat/googlechat.go
+++ b/notify/googlechat/googlechat.go
@@ -22,6 +22,7 @@ import (
 	"net/url"
 	"os"
 	"strings"
+	"unicode/utf8"
 
 	"github.com/go-kit/log"
 	commoncfg "github.com/prometheus/common/config"
@@ -127,6 +128,25 @@ type openLink struct {
 }
 
 type divider struct{}
+
+// Google Chat enforces a ~32 KB total message size limit.
+// We use a conservative threshold to avoid edge cases with encoding overhead.
+const maxPayloadBytes = 24576 // 24 KB
+
+func truncateUTF8(s string, maxBytes int) string {
+	if len(s) <= maxBytes {
+		return s
+	}
+	const suffix = "\n… [truncated]"
+	cut := maxBytes - len(suffix)
+	if cut <= 0 {
+		return ""
+	}
+	for !utf8.RuneStart(s[cut]) {
+		cut--
+	}
+	return s[:cut] + suffix
+}
 
 func buildCard(title, subtitle, imageURL, message, details, actions string) *cardBody {
 	card := &cardBody{}
@@ -262,7 +282,26 @@ func (n *Notifier) Notify(ctx context.Context, alert ...*types.Alert) (bool, err
 		if err := json.NewEncoder(&buf).Encode(payload); err != nil {
 			return false, err
 		}
+		if buf.Len() > maxPayloadBytes {
+			overflow := buf.Len() - maxPayloadBytes
+			if len(cardMessage) > overflow {
+				cardMessage = truncateUTF8(cardMessage, len(cardMessage)-overflow)
+			} else {
+				overflow -= len(cardMessage)
+				cardMessage = ""
+				cardDetails = truncateUTF8(cardDetails, max(0, len(cardDetails)-overflow))
+			}
+			buf.Reset()
+			card = buildCard(cardTitle, cardSubtitle, cardImageURL, cardMessage, cardDetails, cardActions)
+			payload = cardPayload{
+				CardsV2: []cardV2{{CardID: key.Hash(), Card: *card}},
+			}
+			if err := json.NewEncoder(&buf).Encode(payload); err != nil {
+				return false, err
+			}
+		}
 	} else {
+		message = truncateUTF8(message, maxPayloadBytes)
 		if err := json.NewEncoder(&buf).Encode(textMessage{Text: message}); err != nil {
 			return false, err
 		}

--- a/notify/googlechat/googlechat.go
+++ b/notify/googlechat/googlechat.go
@@ -129,9 +129,14 @@ type openLink struct {
 
 type divider struct{}
 
-// Google Chat enforces a ~32 KB total message size limit.
-// We use a conservative threshold to avoid edge cases with encoding overhead.
-const maxPayloadBytes = 24576 // 24 KB
+const (
+	// Google Chat enforces a ~32 KB total message size limit.
+	// We use a conservative threshold to avoid edge cases with encoding overhead.
+	maxPayloadBytes = 24576 // 24 KB
+
+	// Google Chat silently drops card sections when widget count is too high.
+	maxWidgets = 50
+)
 
 func truncateUTF8(s string, maxBytes int) string {
 	if len(s) <= maxBytes {
@@ -171,6 +176,12 @@ func buildCard(title, subtitle, imageURL, message, details, actions string) *car
 
 	if details != "" {
 		widgets := parseKeyValueWidgets(details)
+		if len(widgets) > maxWidgets {
+			widgets = widgets[:maxWidgets]
+			widgets = append(widgets, widget{
+				TextParagraph: &textParagraph{Text: "… more alerts not shown"},
+			})
+		}
 		if len(widgets) > 0 {
 			card.Sections = append(card.Sections, section{
 				Header:                    "Details",

--- a/notify/googlechat/googlechat_test.go
+++ b/notify/googlechat/googlechat_test.go
@@ -351,6 +351,18 @@ func TestBuildCard(t *testing.T) {
 		require.Equal(t, "url", card.Sections[0].Widgets[0].DecoratedText.TopLabel)
 		require.Equal(t, "https://example.com:8080/path", card.Sections[0].Widgets[0].DecoratedText.Text)
 	})
+
+	t.Run("widgets capped at maxWidgets", func(t *testing.T) {
+		var lines []string
+		for i := 0; i < 100; i++ {
+			lines = append(lines, fmt.Sprintf("key-%d: val-%d", i, i))
+		}
+		card := buildCard("Title", "", "", "", strings.Join(lines, "\n"), "")
+		require.Len(t, card.Sections[0].Widgets, maxWidgets+1)
+		last := card.Sections[0].Widgets[maxWidgets]
+		require.NotNil(t, last.TextParagraph)
+		require.Contains(t, last.TextParagraph.Text, "more alerts not shown")
+	})
 }
 
 func TestTruncateUTF8(t *testing.T) {

--- a/notify/googlechat/googlechat_test.go
+++ b/notify/googlechat/googlechat_test.go
@@ -17,10 +17,12 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
 	"os"
+	"strings"
 	"testing"
 	"time"
 
@@ -349,4 +351,114 @@ func TestBuildCard(t *testing.T) {
 		require.Equal(t, "url", card.Sections[0].Widgets[0].DecoratedText.TopLabel)
 		require.Equal(t, "https://example.com:8080/path", card.Sections[0].Widgets[0].DecoratedText.Text)
 	})
+}
+
+func TestTruncateUTF8(t *testing.T) {
+	t.Run("short string unchanged", func(t *testing.T) {
+		require.Equal(t, "hello", truncateUTF8("hello", 100))
+	})
+
+	t.Run("exact limit unchanged", func(t *testing.T) {
+		s := strings.Repeat("a", 500)
+		require.Equal(t, s, truncateUTF8(s, 500))
+	})
+
+	t.Run("over limit gets truncated", func(t *testing.T) {
+		s := strings.Repeat("a", 1000)
+		result := truncateUTF8(s, 500)
+		require.LessOrEqual(t, len(result), 500)
+		require.Contains(t, result, "… [truncated]")
+	})
+
+	t.Run("does not break multi-byte runes", func(t *testing.T) {
+		s := strings.Repeat("日本語", 100) // 3 bytes per rune
+		result := truncateUTF8(s, 50)
+		require.LessOrEqual(t, len(result), 50)
+		for i := 0; i < len(result); {
+			_, size := []rune(result[i:])[0], len(string([]rune(result[i:])[0]))
+			i += size
+		}
+	})
+}
+
+func TestGooglechatTextTruncation(t *testing.T) {
+	var receivedBody []byte
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		receivedBody, _ = io.ReadAll(r.Body)
+	}))
+	defer srv.Close()
+	u, _ := url.Parse(srv.URL)
+
+	cfg := &config.GoogleChatConfig{
+		URL:        &config.SecretURL{URL: u},
+		HTTPConfig: &commoncfg.HTTPClientConfig{},
+		Message:    strings.Repeat("A", maxPayloadBytes+5000),
+	}
+
+	pd, err := New(cfg, test.CreateTmpl(t), log.NewNopLogger())
+	require.NoError(t, err)
+
+	ctx := context.Background()
+	ctx = notify.WithGroupKey(ctx, "test-group")
+
+	ok, err := pd.Notify(ctx, []*types.Alert{
+		{
+			Alert: model.Alert{
+				Labels:   model.LabelSet{"alertname": "TestAlert"},
+				StartsAt: time.Now(),
+				EndsAt:   time.Now().Add(time.Hour),
+			},
+		},
+	}...)
+	require.NoError(t, err)
+	require.False(t, ok)
+
+	require.LessOrEqual(t, len(receivedBody), maxPayloadBytes+200)
+
+	var payload map[string]interface{}
+	require.NoError(t, json.Unmarshal(receivedBody, &payload))
+	text := payload["text"].(string)
+	require.Contains(t, text, "… [truncated]")
+}
+
+func TestGooglechatCardTruncation(t *testing.T) {
+	var receivedBody []byte
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		receivedBody, _ = io.ReadAll(r.Body)
+	}))
+	defer srv.Close()
+	u, _ := url.Parse(srv.URL)
+
+	cfg := &config.GoogleChatConfig{
+		URL:        &config.SecretURL{URL: u},
+		HTTPConfig: &commoncfg.HTTPClientConfig{},
+		CardTitle:   "Alert",
+		CardMessage: strings.Repeat("B", maxPayloadBytes+5000),
+	}
+
+	pd, err := New(cfg, test.CreateTmpl(t), log.NewNopLogger())
+	require.NoError(t, err)
+
+	ctx := context.Background()
+	ctx = notify.WithGroupKey(ctx, "test-group")
+
+	ok, err := pd.Notify(ctx, []*types.Alert{
+		{
+			Alert: model.Alert{
+				Labels:   model.LabelSet{"alertname": "TestAlert"},
+				StartsAt: time.Now(),
+				EndsAt:   time.Now().Add(time.Hour),
+			},
+		},
+	}...)
+	require.NoError(t, err)
+	require.False(t, ok)
+
+	require.LessOrEqual(t, len(receivedBody), maxPayloadBytes+200)
+
+	var payload map[string]interface{}
+	require.NoError(t, json.Unmarshal(receivedBody, &payload))
+	require.Contains(t, payload, "cardsV2")
 }


### PR DESCRIPTION
## Summary
- Google Chat enforces a ~32 KB total message size limit. Large alert groups can produce messages exceeding this, causing `400 "Message content is too long"` errors.
- Adds `truncateUTF8` helper that truncates at safe byte boundaries (no broken multi-byte runes) with a visible `… [truncated]` indicator.
- **Text-only path:** truncates the message to 24 KB before encoding.
- **CardsV2 path:** encodes the payload first, checks size, and if over 24 KB truncates `cardMessage` then `cardDetails` and re-encodes.
- Google chat also drops widgets altogether if they exceed certain number, cap it to 50.

## Test plan
- [x] Unit tests for `truncateUTF8` (short strings, exact limit, over limit, multi-byte safety)
- [x] Integration test for text-only truncation (`TestGooglechatTextTruncation`)
- [x] Integration test for cardsV2 truncation (`TestGooglechatCardTruncation`)
- [x] Verified truncated payload succeeds against live Google Chat webhook
- [x] All existing tests still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)