### PR TITLE
feat(webhook): allow fully custom templated payload

### DIFF
--- a/config/notifiers.go
+++ b/config/notifiers.go
@@ -528,6 +528,13 @@ type WebhookConfig struct {
 	// Alerts exceeding this threshold will be truncated. Setting this to 0
 	// allows an unlimited number of alerts.
 	MaxAlerts uint64 `yaml:"max_alerts" json:"max_alerts"`
+
+	// Payload optionally replaces the default webhook message with a fully
+	// custom payload. Every string key and value is rendered as a Go template
+	// with the standard notification data. It is the operator's responsibility
+	// to ensure the rendered payload is valid JSON in the format expected by
+	// the receiving endpoint.
+	Payload map[string]interface{} `yaml:"payload,omitempty" json:"payload,omitempty"`
 }
 
 // UnmarshalYAML implements the yaml.Unmarshaler interface.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1428,6 +1428,14 @@ url_file: <filepath>
 # above this threshold are truncated. When leaving this at its default value of
 # 0, all alerts are included.
 [ max_alerts: <int> | default = 0 ]
+
+# Define custom payload to be sent to the webhook endpoint.
+# USE AT YOUR OWN RISK: This is an advanced configuration option that allows you
+# to define a custom payload using Go templates. Be aware that the Alertmanager does not
+# perform any validation on the resulting payload, and it is your responsibility to
+# ensure that the generated payload is in the desired format expected by the receiving endpoint.
+# The payload has to be valid JSON. You can use the `toJson` function to help with this.
+[ payload: { <string>: <tmpl_string>, ... } ]
 ```
 
 The Alertmanager

--- a/notify/webhook/webhook.go
+++ b/notify/webhook/webhook.go
@@ -103,6 +103,14 @@ func (n *Notifier) Notify(ctx context.Context, alerts ...*types.Alert) (bool, er
 		return false, err
 	}
 
+	// Override the payload if a custom one is configured.
+	if n.conf.Payload != nil {
+		buf, err = n.renderPayload(msg)
+		if err != nil {
+			return false, fmt.Errorf("failed to render custom payload: %w", err)
+		}
+	}
+
 	var url string
 	if n.conf.URL != nil {
 		url = n.conf.URL.String()
@@ -136,4 +144,31 @@ func errDetails(body io.Reader, url string) string {
 		return url
 	}
 	return fmt.Sprintf("%s: %s", url, string(bs))
+}
+
+// renderPayload renders the user-supplied custom payload template against the
+// notification data and encodes the result as JSON.
+func (n *Notifier) renderPayload(data *Message) (bytes.Buffer, error) {
+	var (
+		tmplTextErr  error
+		tmplText     = notify.TmplText(n.tmpl, data.Data, &tmplTextErr)
+		tmplTextFunc = func(tmpl string) (string, error) {
+			return tmplText(tmpl), tmplTextErr
+		}
+	)
+
+	rendered := make(map[string]interface{}, len(n.conf.Payload))
+	for k, v := range n.conf.Payload {
+		var err error
+		rendered[k], err = template.DeepCopyWithTemplate(v, tmplTextFunc)
+		if err != nil {
+			return bytes.Buffer{}, err
+		}
+	}
+
+	var buf bytes.Buffer
+	if err := json.NewEncoder(&buf).Encode(rendered); err != nil {
+		return bytes.Buffer{}, err
+	}
+	return buf, nil
 }

--- a/notify/webhook/webhook_test.go
+++ b/notify/webhook/webhook_test.go
@@ -15,18 +15,23 @@ package webhook
 
 import (
 	"bytes"
+	"context"
+	"encoding/json"
 	"fmt"
 	"io"
 	"net/http"
 	"net/url"
 	"os"
 	"testing"
+	"time"
 
 	"github.com/go-kit/log"
 	commoncfg "github.com/prometheus/common/config"
+	"github.com/prometheus/common/model"
 	"github.com/stretchr/testify/require"
 
 	"github.com/prometheus/alertmanager/config"
+	"github.com/prometheus/alertmanager/notify"
 	"github.com/prometheus/alertmanager/notify/test"
 	"github.com/prometheus/alertmanager/types"
 )
@@ -138,4 +143,123 @@ func TestWebhookReadingURLFromFile(t *testing.T) {
 	require.NoError(t, err)
 
 	test.AssertNotifyLeaksNoSecret(ctx, t, notifier, u.String())
+}
+
+type roundTripFunc func(req *http.Request) *http.Response
+
+func (f roundTripFunc) RoundTrip(req *http.Request) (*http.Response, error) {
+	return f(req), nil
+}
+
+func testAlerts() []*types.Alert {
+	return []*types.Alert{
+		{
+			Alert: model.Alert{
+				Labels:       model.LabelSet{"alertname": "TestAlert"},
+				Annotations:  model.LabelSet{"summary": "Test summary"},
+				StartsAt:     time.Date(2020, 1, 1, 0, 0, 0, 0, time.UTC),
+				EndsAt:       time.Date(2020, 1, 1, 1, 0, 0, 0, time.UTC),
+				GeneratorURL: "http://generator.url",
+			},
+		},
+	}
+}
+
+// capturePayload posts the given config's notification and returns the raw
+// request body that would have been sent to the webhook endpoint.
+func capturePayload(t *testing.T, conf *config.WebhookConfig, alerts []*types.Alert) []byte {
+	t.Helper()
+
+	var capturedPayload []byte
+	mockTransport := roundTripFunc(func(req *http.Request) *http.Response {
+		var err error
+		capturedPayload, err = io.ReadAll(req.Body)
+		require.NoError(t, err)
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			Body:       http.NoBody,
+		}
+	})
+
+	ctx := notify.WithGroupKey(context.Background(), "{}:{alertname=\"test1\"}")
+	ctx = notify.WithReceiverName(ctx, "test_receiver")
+
+	n, err := New(conf, test.CreateTmpl(t), log.NewNopLogger())
+	require.NoError(t, err)
+	n.client.Transport = mockTransport
+
+	_, err = n.Notify(ctx, alerts...)
+	require.NoError(t, err)
+	require.NotEmpty(t, capturedPayload)
+
+	return capturedPayload
+}
+
+// TestWebhookDefaultPayload tests that the default payload sent by the webhook
+// notifier matches the behaviour before introducing templating.
+func TestWebhookDefaultPayload(t *testing.T) {
+	u, err := url.Parse("http://localhost")
+	require.NoError(t, err)
+
+	conf := &config.WebhookConfig{
+		URL:        &config.SecretURL{URL: u},
+		HTTPConfig: &commoncfg.HTTPClientConfig{},
+	}
+
+	alerts := testAlerts()
+	tmpl := test.CreateTmpl(t)
+	ctx := notify.WithGroupKey(context.Background(), "{}:{alertname=\"test1\"}")
+	ctx = notify.WithReceiverName(ctx, "test_receiver")
+	data := notify.GetTemplateData(ctx, tmpl, alerts, log.NewNopLogger())
+
+	msg := &Message{
+		Version:  "4",
+		Data:     data,
+		GroupKey: "{}:{alertname=\"test1\"}",
+	}
+
+	var buf bytes.Buffer
+	require.NoError(t, json.NewEncoder(&buf).Encode(msg))
+
+	require.JSONEq(t, buf.String(), string(capturePayload(t, conf, alerts)))
+}
+
+func TestWebhookCustomPayload(t *testing.T) {
+	u, err := url.Parse("http://localhost")
+	require.NoError(t, err)
+
+	conf := &config.WebhookConfig{
+		URL:        &config.SecretURL{URL: u},
+		HTTPConfig: &commoncfg.HTTPClientConfig{},
+		Payload: map[string]interface{}{
+			"custom":       `some custom content`,
+			"commonLabels": "{{ .CommonLabels | toJson }}",
+			"status":       "{{ .Status }}",
+			"nested": map[string]interface{}{
+				"alerts": []interface{}{
+					map[string]interface{}{
+						"name": "{{ .CommonLabels.alertname }}",
+					},
+				},
+			},
+		},
+	}
+
+	expected := map[string]interface{}{
+		"custom":       `some custom content`,
+		"commonLabels": map[string]string{"alertname": "TestAlert"},
+		"status":       "resolved",
+		"nested": map[string]interface{}{
+			"alerts": []interface{}{
+				map[string]interface{}{
+					"name": "TestAlert",
+				},
+			},
+		},
+	}
+
+	var buf bytes.Buffer
+	require.NoError(t, json.NewEncoder(&buf).Encode(expected))
+
+	require.JSONEq(t, buf.String(), string(capturePayload(t, conf, testAlerts())))
 }

--- a/template/template.go
+++ b/template/template.go
@@ -15,6 +15,7 @@ package template
 
 import (
 	"bytes"
+	"encoding/json"
 	"fmt"
 	tmplhtml "html/template"
 	"io"
@@ -22,6 +23,7 @@ import (
 	"net/url"
 	"path"
 	"path/filepath"
+	"reflect"
 	"regexp"
 	"sort"
 	"strconv"
@@ -33,6 +35,7 @@ import (
 	"golang.org/x/text/cases"
 	"golang.org/x/text/language"
 	"golang.org/x/text/message"
+	"gopkg.in/yaml.v2"
 
 	"github.com/prometheus/alertmanager/asset"
 	"github.com/prometheus/alertmanager/types"
@@ -195,6 +198,16 @@ var DefaultFuncs = FuncMap{
 	},
 	"stringSlice": func(s ...string) []string {
 		return s
+	},
+	// toJson marshals the given value to its JSON representation. It is mainly
+	// useful to embed structured data (e.g. .CommonLabels) into a custom
+	// webhook payload.
+	"toJson": func(v interface{}) (string, error) {
+		b, err := json.Marshal(v)
+		if err != nil {
+			return "", err
+		}
+		return string(b), nil
 	},
 	"now": time.Now,
 	"unix": func(t time.Time) int64 {
@@ -455,4 +468,109 @@ func (t *Template) Data(recv string, groupLabels model.LabelSet, alerts ...*type
 	}
 
 	return data
+}
+
+// TemplateFunc renders a template string against some data, returning the
+// rendered string or an error.
+type TemplateFunc func(string) (string, error)
+
+// DeepCopyWithTemplate returns a deep copy of a map/slice/array/string/int/bool or combination thereof, executing the
+// provided template (with the provided data) on all string keys or values. All maps are converted to
+// map[string]interface{}, with all non-string keys discarded.
+func DeepCopyWithTemplate(value interface{}, tmplTextFunc TemplateFunc) (interface{}, error) {
+	if value == nil {
+		return value, nil
+	}
+
+	valueMeta := reflect.ValueOf(value)
+	switch valueMeta.Kind() {
+	case reflect.String:
+		parsed, err := tmplTextFunc(value.(string))
+		if err != nil {
+			return parsed, err
+		}
+		var inlineType interface{}
+		if err := yaml.Unmarshal([]byte(parsed), &inlineType); err != nil ||
+			(inlineType != nil && reflect.TypeOf(inlineType).Kind() == reflect.String) {
+			// The rendered string is not structured data, keep it as a string.
+			return parsed, nil
+		}
+		// inlineType holds structured data decoded from the rendered string.
+		// This is already final data, so only normalize it into JSON-compatible
+		// types. It must not be passed back through DeepCopyWithTemplate, because
+		// re-templating and re-parsing its leaf values would reinterpret strings
+		// that merely look like YAML (e.g. "value1:" becoming a map).
+		return normalizeYAMLValue(inlineType), nil
+
+	case reflect.Array, reflect.Slice:
+		arrayLen := valueMeta.Len()
+		converted := make([]interface{}, arrayLen)
+		for i := 0; i < arrayLen; i++ {
+			var err error
+			converted[i], err = DeepCopyWithTemplate(valueMeta.Index(i).Interface(), tmplTextFunc)
+			if err != nil {
+				return nil, err
+			}
+		}
+		return converted, nil
+
+	case reflect.Map:
+		keys := valueMeta.MapKeys()
+		converted := make(map[string]interface{}, len(keys))
+
+		for _, keyMeta := range keys {
+			strKey, isString := keyMeta.Interface().(string)
+			if !isString {
+				continue
+			}
+			renderedKey, err := tmplTextFunc(strKey)
+			if err != nil {
+				return nil, err
+			}
+			converted[renderedKey], err = DeepCopyWithTemplate(valueMeta.MapIndex(keyMeta).Interface(), tmplTextFunc)
+			if err != nil {
+				return nil, err
+			}
+		}
+		return converted, nil
+
+	default:
+		return value, nil
+	}
+}
+
+// normalizeYAMLValue recursively converts a value decoded by yaml.Unmarshal into
+// JSON-compatible types: maps become map[string]interface{} (non-string keys are
+// dropped, mirroring DeepCopyWithTemplate) and slices/arrays become
+// []interface{}. Scalar leaves are returned unchanged, so values are never
+// re-templated or re-parsed. This keeps a rendered JSON payload byte-for-byte
+// faithful instead of reinterpreting string values that happen to be valid YAML.
+func normalizeYAMLValue(value interface{}) interface{} {
+	if value == nil {
+		return nil
+	}
+
+	valueMeta := reflect.ValueOf(value)
+	switch valueMeta.Kind() {
+	case reflect.Array, reflect.Slice:
+		converted := make([]interface{}, valueMeta.Len())
+		for i := range converted {
+			converted[i] = normalizeYAMLValue(valueMeta.Index(i).Interface())
+		}
+		return converted
+
+	case reflect.Map:
+		converted := make(map[string]interface{}, valueMeta.Len())
+		for _, keyMeta := range valueMeta.MapKeys() {
+			strKey, isString := keyMeta.Interface().(string)
+			if !isString {
+				continue
+			}
+			converted[strKey] = normalizeYAMLValue(valueMeta.MapIndex(keyMeta).Interface())
+		}
+		return converted
+
+	default:
+		return value
+	}
 }


### PR DESCRIPTION
Backport of [prometheus/alertmanager#5011](https://github.com/prometheus/alertmanager/pull/5011) onto our v0.27.0 fork.

## What

Adds an optional `payload` field to `webhook_config`. When set, it replaces the default webhook message entirely. Every string key and value in the (arbitrarily nested) payload is rendered as a Go template against the standard notification data, so the operator controls the exact JSON body posted to the endpoint.

```yaml
webhook_configs:
  - url: https://example.com/hooks/oodle
    payload:
      text: '{{ .CommonLabels.alertname }} is {{ .Status }}'
      labels: '{{ .CommonLabels | toJson }}'
      card:
        sections:
          - header: '{{ .Status }}'
```

This is what lets a webhook notifier target an endpoint with its own request format without us adding a dedicated notifier type for it.

## Backported support

Neither piece exists at v0.27.0, so both came from upstream `main`:

- `template.DeepCopyWithTemplate` / `normalizeYAMLValue`, which walk the payload and render string leaves. A rendered string that parses as structured YAML/JSON is inlined (so `toJson` output becomes a real object rather than a quoted string) and then only normalized, never re-templated — that last part is upstream's fix for [#5302](https://github.com/prometheus/alertmanager/issues/5302), included here so we don't inherit the bug.
- The `toJson` template function.

Adapted for Go 1.21 (no `reflect.TypeAssert`, no range-over-int) and for the fork's `config.SecretURL` / go-kit logging.

## Tests

`TestWebhookDefaultPayload` pins the unchanged default body; `TestWebhookCustomPayload` covers nesting, `toJson` inlining, and scalar templates. `go test ./notify/... ./template/` is clean.

`config`'s `TestEmptyFieldsAndRegex` fails on `master-oodle` before this change too — unrelated, untouched here.

## Follow-ups

Both `oodle` and `oodle-cortex` vendor this fork and need the pin bumped to pick this up. `oodle-cortex` is the one that actually sends notifications in production.

🤖 Generated with [Claude Code](https://claude.com/claude-code)